### PR TITLE
Changing the variable name from "patch.diff" to "patchDiff"

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/patch/PatchParameterDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/patch/PatchParameterDefinition.java
@@ -68,5 +68,5 @@ public class PatchParameterDefinition extends FileParameterDefinition {
         }
     }
 
-    static final String LOCATION = "patch.diff";
+    static final String LOCATION = "patchDiff";
 }


### PR DESCRIPTION
If the variable name is "patch.diff" it makes it impossible to use in a pipeline shell script. In general its not a good naming convention either. Changing the name to more generic "patchDiff"