### PR TITLE
Remove usage of deprecated IOException2

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/patch/ApplyTask.java
+++ b/src/main/java/org/jenkinsci/plugins/patch/ApplyTask.java
@@ -5,7 +5,7 @@ import com.cloudbees.diff.ContextualPatch.PatchReport;
 import com.cloudbees.diff.PatchException;
 import hudson.FilePath.FileCallable;
 import hudson.remoting.VirtualChannel;
-import hudson.util.IOException2;
+import hudson.util.IOException;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,7 +26,7 @@ class ApplyTask implements FileCallable<Void> {
                     throw new IOException("Failed to patch " + r.getFile(), r.getFailure());
             }
         } catch (PatchException e) {
-            throw new IOException2("Failed to apply the patch: "+diff,e);
+            throw new IOException("Failed to apply the patch: "+diff,e);
         }
 
         return null;


### PR DESCRIPTION
## Remove usage of deprecated IOException2

Removes usage of deprecated `hudson.util.IOException2` by replacing it with `java.io.IOException`

### Testing done

None, rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue